### PR TITLE
Fix typo in generated desktop files

### DIFF
--- a/README
+++ b/README
@@ -19,13 +19,13 @@ To install this module type the following:
 DEPENDENCIES
 
 This module expects the freedesktop mime database to be installed,
-some linux distrobutions include it, otherwise it can obtained 
+some linux distributions include it, otherwise it can obtained 
 from :
 
   http://freedesktop.org/Software/shared-mime-info
 
 This module requires these other modules which can be obtained from
-the CPAN <http://cpan.org> if they are not allready installed on
+the CPAN <http://cpan.org> if they are not already installed on
 your system :
 
   Carp

--- a/lib/File/MimeInfo/Applications.pm
+++ b/lib/File/MimeInfo/Applications.pm
@@ -72,7 +72,7 @@ sub mime_applications_set_custom {
 	$object->set(
 		Type      => 'Application',
 		Name      => $word,
-		NoDsiplay => 'true',
+		NoDisplay => 'true',
 		Exec      => $command,
 	);
 	my (undef, undef, $df) = File::Spec->splitpath($desktop_file);


### PR DESCRIPTION
Desktop files generated by e.g. entering a custom application at
the mimeopen -d prompt would get a "NoDsiplay" (rather than
"NoDisplay") entry.