### PR TITLE
Fix ARGV encoding issues

### DIFF
--- a/mimeopen
+++ b/mimeopen
@@ -7,6 +7,10 @@ $|++;
 # ########## #
 # Parse ARGV #
 # ########## #
+use Encode::Locale;
+use Encode;
+@ARGV = map { decode(locale => $_, 1) } @ARGV;
+
 my %args = ();
 my %opts = (
 	# name	=> [char, expect_arg_bit ]

--- a/mimetype
+++ b/mimetype
@@ -7,6 +7,10 @@ $|++;
 # ########## #
 # Parse ARGV #
 # ########## #
+use Encode::Locale;
+use Encode;
+@ARGV = map { decode(locale => $_, 1) } @ARGV;
+
 my %args = ();
 my %opts = (
 	# name	=> [char, expect_arg_bit ]


### PR DESCRIPTION
I ran into this when I tried to use `mimeopen` to open files with greek names:
```
$ mimeopen -n /mnt/movies/movies/Ellhnika/Ευδοκία\ \(1971\)/Ευδοκία.avi 
Opening "/mnt/movies/movies/Ellhnika/Ευδοκία (1971)/Ευδοκία.avi" with VLC media player  (video/x-msvideo)
/mnt/movies/movies/Ellhnika/%C3%8E%C2%95%C3%8F%C2%85%C3%8E%C2%B4%C3%8E%C2%BF%C3%8E%C2%BA%C3%8E%C2%AF%C3%8E%C2%B1%20%281971%29/%C3%8E%C2%95%C3%8F%C2%85%C3%8E%C2%B4%C3%8E%C2%BF%C3%8E%C2%BA%C3%8E%C2%AF%C3%8E%C2%B1.avi
VLC media player 2.2.6 Umbrella (revision 2.2.6-0-g1aae78981c)
[000055d6004ccbc8] [http] lua interface: Lua HTTP interface
[000055d600396eb8] core libvlc: Running vlc with the default interface. Use 'cvlc' to use vlc without interface.
"sni-qt/31804" WARN  16:45:23.578 void StatusNotifierItemFactory::connectToSnw() Invalid interface to SNW_SERVICE 
[00007fa4fc000f48] filesystem access error: cannot open file /mnt/movies/movies/Ellhnika/ÎÏÎ´Î¿ÎºÎ¯Î± (1971)/ÎÏÎ´Î¿ÎºÎ¯Î±.avi (No such file or directory)
[00007fa510004378] core input error: open of `file:///mnt/movies/movies/Ellhnika/%C3%8E%C2%95%C3%8F%C2%85%C3%8E%C2%B4%C3%8E%C2%BF%C3%8E%C2%BA%C3%8E%C2%AF%C3%8E%C2%B1%20%281971%29/%C3%8E%C2%95%C3%8F%C2%85%C3%8E%C2%B4%C3%8E%C2%BF%C3%8E%C2%BA%C3%8E%C2%AF%C3%8E%C2%B1.avi' failed
```
and I've seen that other people (issues #15 #17) have the same problem.

perl like python-2.x will treat the arguments passed to the command line as bytestrings:

```perl
$ cat args.pl 
#!/usr/bin/env perl

foreach $c (split ('', $ARGV[0])) {
	printf ord($c)." ";
}
print "ARGV[0] length:".length($ARGV[0])."\n";
```
```
$ ./args.pl aaa
97 97 97 ARGV[0] length:3
$ ./args.pl ααα
206 177 206 177 206 177 ARGV[0] length:6
```
The arguments have been encoded to UTF-8 by the shell because of the locale I'm using. The 3 greek letters will create a byte-string of length 6.

When `mimeopen` runs, it will eventually execute this:
```perl
 $default->exec(@ARGV);
```
to open the file with the chosen application. The `$default` variable contains a `DesktopEntry` object. If the `Exec` key of the *.desktop file, this object refers to, has a `%f` or `%F` and the argument is not a URI (it does not start with `file:/`), the execution will probably work. But if the `Exec` key contains `%u` or `%U`, `exec()` will try to construct a URI and will run:
```perl
 $uri .= join '/', map { uri_escape_utf8($_) } File::Spec->splitdir($directories . $file);
```
The `uri_escape_utf8` function is from the URI package and looks like this:
```perl
sub uri_escape_utf8 {
    my $text = shift;
    utf8::encode($text);
    return uri_escape($text, @_);
}
```
The already encoded ARGV string will be re-encoded and if it contains multi-byte (non-ascii characters), the constructed URI will be wrong:

The greek alpha (α) which should be encoded to: `%CE%B1` will be encoded to: `%C3%8E%C2%B1`. This is because the 2 bytes of the UTF-8 encoding of α (206 177 or `0xce` and `0xb1`) will be treated as the unicode characters U+00CE and U+00B1 (the character Î and ±) which are represented in UTF-8 as `0xc38e` and `0xc2b1`.

I think the best thing to do is decode @ARGV to convert it to a character string based on the locale.
