### PR TITLE
Fix #36 : restore and move the check for defined($default) before opening the file.

### DIFF
--- a/mimeopen
+++ b/mimeopen
@@ -136,13 +136,6 @@ unless (length $mimetype) {
 
 my ($default, @other) = mime_applications_all($mimetype);
 
-## Removed this because user should always be able to select "Other..."
-#unless($default or @other) {
-#	print STDERR "No applications found for mimetype: $mimetype\n";
-#	exit 6;
-#}
-##
-
 if    ($args{'no-ask'}) {
 	$default = defined($default) ? $default : $other[0];
 }
@@ -154,6 +147,12 @@ elsif ($args{'ask-default'}) {
 }
 elsif (! defined $default) {
 	($default) = (@other == 1) ? (@other) : choose($mimetype, 1, @other);
+}
+
+unless($default) {
+	# $default can still be undef, if $other[0] is undef and no-ask is set.
+	print STDERR "No applications found for mimetype: $mimetype\n.";
+	exit 6;
 }
 
 print 'Opening '.join(', ', map qq{"$_"}, @ARGV)


### PR DESCRIPTION
This simply checks if `$default` is `undef` before using it. Do nothing and exit with `6` otherwise.
It seems this check used to exist, then got commented. It is commented in the original import from 0.16, so a long time ago.