### PR TITLE
Adjust Makefile.PL to use PREREQ_PM

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile (
   'VERSION_FROM'     => 'lib/File/MimeInfo.pm',
   'LICENSE'          => 'perl',
   'MIN_PERL_VERSION' => '5.6.1',
-  'BUILD_REQUIRES'   => {
+  'PREREQ_PM'   => {
     'Carp'               => 0,
     'Exporter'           => 0,
     'Fcntl'              => 0,


### PR DESCRIPTION
The dependencies list was using BUILD_REQUIRES
which list modules used to build the distribution

To list dependencies required at run time you
should use PREREQ_PM.