### PR TITLE
Fix for issue #43

### DIFF
--- a/lib/File/MimeInfo/Applications.pm
+++ b/lib/File/MimeInfo/Applications.pm
@@ -101,8 +101,8 @@ sub _default {
     }
 
     $Carp::CarpLevel++;
-    my @list =
-    _read_list($mimetype, $user, $system, $deprecated, $distro, $legacy);
+    my @paths = grep defined, ($mimetype, $user, $system, $deprecated, $distro, $legacy);
+    my @list = _read_list(@paths);
     my $desktop_file = _find_file(reverse @list);
     $Carp::CarpLevel--;
 


### PR DESCRIPTION
Should fix multiple warnings of the form of:
`Use of uninitialized value $file in open at /usr/lib64/perl5/vendor_perl/5.34/File/MimeInfo/Applications.pm line 140`

Essentially, removes undefined paths from the argument list passed to look for applications

Should resolve #43 