### PR TITLE
Prevent uninitialized variable warning in File::BaseDir

### DIFF
--- a/lib/File/MimeInfo/Applications.pm
+++ b/lib/File/MimeInfo/Applications.pm
@@ -178,7 +178,7 @@ sub _write_list {
 }
 
 sub _find_file {
-    my @list = shift;
+    my @list = @_;
     for (@list) {
         my $file = data_files('applications', $_);
         return File::DesktopEntry->new($file) if $file;


### PR DESCRIPTION
I noticed that I get a warning when using `mimeopen`: "`Use of uninitialized value in subroutine entry at /usr/share/perl5/vendor_perl/File/BaseDir.pm line 105.`" (see [here](https://github.com/uperl/File-BaseDir/blob/a45688168a02ac3c5ec731d3068a82702341ebd0/lib/File/BaseDir.pm#L105) for the corresponding code, which causing the warning)

I investigated and found, that line 181 (`my @list = shift;`) seems to be the erroneous line.
Two wierd things happen here: First: `shift` returns a scalar, which is then converted into a list with a single element. This seems wrong, especially because later we loop over that very list, which would be unnecessary, if we only have one element.
Second: If the function is called with no arguments (see also [line 106](https://github.com/mbeijen/File-MimeInfo/blob/d40620d42093a5f500563452fcd882654eb3f3f0/lib/File/MimeInfo/Applications.pm#L106), for the code that calls the function), `shift` returns `undefined`, creating a list of only one `undefined` value, which causes the previously described error / warning.

What I think is actually intended here is to copy the arguments into a list, which would also fix the mentioned warning.